### PR TITLE
Changes for TouchDesigner integration

### DIFF
--- a/lib/include/laserdocklib/LaserdockDevice.h
+++ b/lib/include/laserdocklib/LaserdockDevice.h
@@ -73,6 +73,7 @@ public:
     unsigned char *usb_get(unsigned char * data, int length);
 
     void print() const;
+    int sdescription(char* buff, int bufferSize);
 
 private:
     std::unique_ptr<LaserdockDevicePrivate> d;

--- a/lib/src/LaserdockDevice.cpp
+++ b/lib/src/LaserdockDevice.cpp
@@ -349,6 +349,8 @@ bool LaserdockDevice::runner_mode_load(LaserdockSample *samples, uint16_t positi
 
 uint16_t float_to_laserdock_xy(float var)
 {
+    if (var < -1) var = -1;
+    if (var > 1) var = 1;
     uint16_t val = (4095 * (var + 1.0)/2.0);
     return val;
 }

--- a/lib/src/LaserdockDevice.cpp
+++ b/lib/src/LaserdockDevice.cpp
@@ -182,9 +182,14 @@ unsigned char *LaserdockDevice::usb_get(unsigned char * data, int length){
 
 void LaserdockDevice::print() const
 {
-    d->print();
+    char* desc;
+    int dc = d->sdescription(desc, 64);
+    printf("%s\n", desc);
 }
 
+int LaserdockDevice::sdescription(char* buffer, int bufferSize) {
+    return d->sdescription(buffer, bufferSize);
+}
 
 bool LaserdockDevice::get_output(bool *enabled) {
     uint8_t enabled8;
@@ -386,7 +391,7 @@ void LaserdockDevicePrivate::release(){
     //            fprintf(stderr, "Error releasing interface 1\n");
 }
 
-void LaserdockDevicePrivate::print() const
+int LaserdockDevicePrivate::sdescription(char* buffer, int bufferSize)
 {
     struct libusb_device_descriptor device_descriptor;
 
@@ -397,14 +402,17 @@ void LaserdockDevicePrivate::print() const
     }
 
     //  print our devices
-    printf("0x%04x 0x%04x", device_descriptor.idVendor, device_descriptor.idProduct);
+    int bc = sprintf_s(buffer, bufferSize, "0x%04x 0x%04x", device_descriptor.idVendor, device_descriptor.idProduct);
 
     // Print the device manufacturer string
     char manufacturer[256] = " ";
     if (device_descriptor.iManufacturer) {
         libusb_get_string_descriptor_ascii(devh_ctl, device_descriptor.iManufacturer,
-                                           (unsigned char *)manufacturer, sizeof(manufacturer));
-        printf(" %s\n", manufacturer);
+            (unsigned char*)manufacturer, sizeof(manufacturer));
+        
+        bc += sprintf_s(buffer, bufferSize, "%s %s", buffer, manufacturer);
     }
-}
+    
+    return bc;
 
+}

--- a/lib/src/LaserdockDeviceManager.cpp
+++ b/lib/src/LaserdockDeviceManager.cpp
@@ -27,7 +27,8 @@ std::vector<std::unique_ptr<LaserdockDevice> > LaserdockDeviceManager::get_laser
 void LaserdockDeviceManager::print_laserdock_devices() {
     std::vector<std::unique_ptr<LaserdockDevice> > devices = get_laserdock_devices();
     for(const std::unique_ptr<LaserdockDevice> &device : devices) {
-        device->print();
+        char* d;
+        printf("%s\n", device->sdescription(d, 64));
     }
 }
 

--- a/lib/src/LaserdockDevice_p.h
+++ b/lib/src/LaserdockDevice_p.h
@@ -5,6 +5,7 @@
 #ifndef LASERDOCKLIB_LASERDOCKDEVICEPRIVATE_H
 #define LASERDOCKLIB_LASERDOCKDEVICEPRIVATE_H
 
+#include <string>
 
 #ifdef ANDROID
 class _jobject;
@@ -34,9 +35,11 @@ public:
     void initialize();
     void release();
     void print() const;
+    int sdescription(char* buff, int bufferSize);
 
 private:
     LaserdockDevice * q;
+    int _description(char* buffer, int bufferSize);
 };
 
 


### PR DESCRIPTION
- LaserdockDevice::sdescription - set the description via char* buffer. This is used to display the device names in TD.
- float_to_laserdock_xy - set min and max values. Ensures the output remains in a valid range for uint16_t.